### PR TITLE
Add "deprecated" field to the OpenAPIOperation struct

### DIFF
--- a/openapi2mcp.go
+++ b/openapi2mcp.go
@@ -21,6 +21,7 @@ type OpenAPIOperation struct {
 	RequestBody *openapi3.RequestBodyRef
 	Tags        []string
 	Security    openapi3.SecurityRequirements
+	Deprecated  bool
 }
 
 // ToolGenOptions controls tool generation and output for OpenAPI-MCP conversion.

--- a/spec.go
+++ b/spec.go
@@ -187,6 +187,7 @@ func ExtractOpenAPIOperations(doc *openapi3.T) []OpenAPIOperation {
 				RequestBody: op.RequestBody,
 				Tags:        tags,
 				Security:    security,
+				Deprecated:  op.Deprecated,
 			})
 		}
 	}


### PR DESCRIPTION
I need to filter out some operations based on the `deprecated` field. While it can be achieved by adding a new tag, we are already using this `deprecated: true` field in our API specs. 

This PR is just to expose this field so that we can use it from other places.
I also wonder if we even want to embed the `*openapi3.Operation` in the `OpenAPIOperation` struct, but, for now, I kept the changes to a minimum.

Also, we could have something similar to the `TagFilter` and have this implemented here as well. Happy to do so, but before jumping in, I'd like to confirm/double-check it.

PS: thank you for forking the original project and starting to maintain it!