### PR TITLE
Fix TagFilter when the first tag does not match

### DIFF
--- a/cmd/openapi-mcp/utils.go
+++ b/cmd/openapi-mcp/utils.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"slices"
 
 	openapi2mcp "github.com/evcc-io/openapi-mcp"
 	"github.com/getkin/kin-openapi/openapi3"
@@ -38,12 +39,10 @@ func compareWithDiffFile(opts *openapi2mcp.ToolGenOptions, doc *openapi3.T, ops 
 	for _, op := range ops {
 		if len(opts.TagFilter) > 0 {
 			found := false
-			for _, tag := range op.Tags {
-				for _, want := range opts.TagFilter {
-					if tag == want {
-						found = true
-						break
-					}
+			for _, tag := range opts.TagFilter {
+				if slices.Contains(op.Tags, tag) {
+					found = true
+					break
 				}
 			}
 			if !found {

--- a/register.go
+++ b/register.go
@@ -359,10 +359,14 @@ func RegisterOpenAPITools(server *mcp.Server, ops []OpenAPIOperation, doc *opena
 		if opts == nil || len(opts.TagFilter) == 0 {
 			return true
 		}
-		for _, tag := range op.Tags {
-			return slices.Contains(opts.TagFilter, tag)
+		found := false
+		for _, tag := range opts.TagFilter {
+			if slices.Contains(op.Tags, tag) {
+				found = true
+				break
+			}
 		}
-		return false
+		return found
 	}
 
 	for _, op := range ops {


### PR DESCRIPTION
I've noticed that the TagFilter is not working as expected: if the first tag does not match one of the ones passed in the TagFilter, the operation will get entirely skipped. 
This approach works for 1-tag operations, but if an operation is tagged with multiple tags, then the order of them can have undesired effects during the filtering.

This PR adds a unit test case covering this case and adds a fix for it.